### PR TITLE
Fix for unreliable wake-up port detection + DHCP and retry options

### DIFF
--- a/Episode_007/esp32/mailbox/mailbox.ino
+++ b/Episode_007/esp32/mailbox/mailbox.ino
@@ -53,7 +53,7 @@ void setup()
             wakePort = 26;
           }
         }
-        if (WakePort != 0) Serial.println ("Wakeup triggered by port: " + String(wakePort));
+        if (wakePort != 0) Serial.println ("Wakeup triggered by port: " + String(wakePort));
     }
 
     if (wakePort == 25 || wakePort == 26) {

--- a/Episode_007/esp32/mailbox/mailbox.ino
+++ b/Episode_007/esp32/mailbox/mailbox.ino
@@ -22,50 +22,53 @@ const int mqttPort = 1883; // MQTT port (default: 1883)
 const int retryWaitTime = 30; // Retry wait time in minutes
 const int retryMaxTimes = 5; // Maximum retry times
 
-char* state;
-RTC_DATA_ATTR int retryCount;
-RTC_DATA_ATTR char* retryState;
+int wakePort;
+RTC_DATA_ATTR int retryCount = 0;
+RTC_DATA_ATTR int retryPort = 0;
 
 void setup()
 {
     Serial.begin(115200);
-    delay(100); // Take some time to open up the Serial Monitor
     Serial.println("Starting up...");
+    Serial.println();
+    
+    int wakeupStatus = esp_sleep_get_ext1_wakeup_status();
 
-    // get wakeup bit
-    uint64_t wakeupBit = esp_sleep_get_ext1_wakeup_status();
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
 
-    // if it didnt woke because of flap or door or retry timer, we only need to configure internal pullups/downs.
-    if (esp_sleep_get_wakeup_cause() == 2 || esp_sleep_get_wakeup_cause() == 3) { // 2 is GPIO, 3 is retry timer
-        if (esp_sleep_get_wakeup_cause() == 3) { // retry timer
-            Serial.print("Retry processing previous state: ");
-            Serial.println(retryState);
-            Serial.print("Retry count: ");
-            Serial.println(retryCount);
-            state = retryState;
+    Serial.println("wakeupStatus: " + String(wakeupStatus));
+    Serial.println("retryPort: " + String(retryPort));
+    Serial.println("retryCount: " + String(retryCount));
+
+    if (wakeupStatus == 0 && retryPort != 0) {
+        wakePort = retryPort;
+        Serial.println ("Retry previously triggered wakePort: " + String(wakePort));
+    } else {
+        if (wakeupStatus != 0) {
+          wakePort = log(wakeupStatus)/log(2);
+        } else {
+          if (digitalRead(25)) {
+            wakePort = 25;
+          } else if (digitalRead(26)) {
+            wakePort = 26;
+          }
         }
-        else { // mail arrived or emptied
-            if (wakeupBit & GPIO_SEL_25) {
-                state = "arrived";
-            }
-            else {
-                state = "emptied";
-            }
-        }
+        if (WakePort != 0) Serial.println ("Wakeup triggered by port: " + String(wakePort));
+    }
 
-        Serial.print("Connecting to ");
-        Serial.print(ssid);
+    if (wakePort == 25 || wakePort == 26) {
+        retryPort = wakePort;
+        Serial.print("Connecting to " + String(ssid));
 
         // Setup WiFi
         WiFiClient espClient;
-        if (!useDHCP)
-            WiFi.config(ip, gateway, subnet);
+        if (!useDHCP) WiFi.config(ip, gateway, subnet);
         WiFi.begin(ssid, password);
-
+ 
         int trycount = 0;
-        // try to connect to WiFi for another 10 seconds
-        while (WiFi.status() != WL_CONNECTED && trycount <= 10) {
-            delay(1000);
+        // try to connect to WiFi for another 15 seconds
+        while (WiFi.status() != WL_CONNECTED && trycount <= 15) {
+            delay(500);
             Serial.print(".");
             trycount++;
         }
@@ -80,37 +83,33 @@ void setup()
             PubSubClient client(espClient);
             client.setServer(mqttServer, mqttPort);
 
-            trycount = 0; // reset trycount
-            // try to connect to MQTT server, retry two times if connection fails
-            while (!client.connected() && trycount <= 2) {
-                if (client.connect("Mailbox", mqttUser, mqttPassword)) {
-                    Serial.println("MQTT connected");
-                }
-                else {
-                    Serial.print("Failed with state ");
-                    Serial.println(client.state());
-                    delay(1000);
-                }
-                trycount++;
-            }
-
-            if (client.connected()) {
-                resetRetry();
-                if (state == "arrived") {
-                    client.publish("mailbox/action", "arrived");
+            if (client.connect("Mailbox", mqttUser, mqttPassword)) {
+                if (wakePort == 25) {
+                    for (int i = 0; i < 3; i++) {
+                      client.publish("mailbox/action", "arrived");
+                      delay(100);
+                    }
                     Serial.println("A letter arrived, arming door");
                     esp_sleep_enable_ext1_wakeup(GPIO_SEL_26, ESP_EXT1_WAKEUP_ANY_HIGH);
-                }
-                else if (state == "emptied") {
-                    client.publish("mailbox/action", "emptied");
+                    gpio_pulldown_en(GPIO_NUM_26);
+                } else {
+                    for (int i = 0; i < 3; i++) {
+                      client.publish("mailbox/action", "emptied");
+                      delay(100);
+                    }
                     Serial.println("Mailbox emptied, arming flap");
                     esp_sleep_enable_ext1_wakeup(GPIO_SEL_25, ESP_EXT1_WAKEUP_ANY_HIGH);
+                    gpio_pulldown_en(GPIO_NUM_25);
                 }
+                resetRetry();
             }
             else {
                 Serial.println("Unable to connect to MQTT server");
                 retry();
             }
+
+            // disconnect from MQTT
+            client.disconnect();
         }
         else {
             Serial.println("Unable to connect to WiFi network");
@@ -119,38 +118,28 @@ void setup()
 
         // disconnect WiFi
         WiFi.disconnect();
-    }
-    else {
-        Serial.println("Arming flap and door");
+    } else {
+        gpio_pulldown_en(GPIO_NUM_25);
+        gpio_pulldown_en(GPIO_NUM_26);
         esp_sleep_enable_ext1_wakeup(GPIO_SEL_25 | GPIO_SEL_26, ESP_EXT1_WAKEUP_ANY_HIGH);
     }
 
-    /*
-    we need the internal pullups/downs to work so we need an option to keep the power for them on during sleep.
-    note: when you use external pulldowns (10K) instead of the internal ones you can save around 10µA in deepsleep  (then comment out the next 5 lines)
-    note2: don't use gpio34-39 when using internal pullup/downs - they don't have them.
-    */
-
-    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-    gpio_pullup_dis(GPIO_NUM_25);
-    gpio_pulldown_en(GPIO_NUM_25);
-    gpio_pullup_dis(GPIO_NUM_26);
-    gpio_pulldown_en(GPIO_NUM_26);
-
     // Go to deep sleep
     Serial.println("Going to sleep now...");
+
     esp_deep_sleep_start();
+    Serial.println("This will never be printed");
 }
 
 void retry()
 {
-    // with or without retry mode enabled, listen to GPIO ports
-    esp_sleep_enable_ext1_wakeup(GPIO_SEL_25 | GPIO_SEL_26, ESP_EXT1_WAKEUP_ANY_HIGH);
     if (retryCount < retryMaxTimes) {
         Serial.println("An error has occurred, let's try again later");
         ++retryCount;
-        retryState = state;
         esp_sleep_enable_timer_wakeup(retryWaitTime * 60000000);
+        gpio_pulldown_en(GPIO_NUM_25);
+        gpio_pulldown_en(GPIO_NUM_26);
+        esp_sleep_enable_ext1_wakeup(GPIO_SEL_25 | GPIO_SEL_26, ESP_EXT1_WAKEUP_ANY_HIGH);
     }
     else {
         Serial.println("Retry failed again. I give up, sorry.");
@@ -160,9 +149,10 @@ void retry()
 
 void resetRetry()
 {
+    Serial.println("Resetting retry data");
     // reset any retry counts and states
     retryCount = 0;
-    retryState = "cleared";
+    retryPort = 0;
 }
 
 void loop()

--- a/Episode_007/esp32/mailbox/mailbox.ino
+++ b/Episode_007/esp32/mailbox/mailbox.ino
@@ -2,116 +2,170 @@
 #include <PubSubClient.h>
 #include <Wire.h>
 
+// WiFi configuration
+const char* ssid = "your_ssid_here"; // WiFi SSID
+const char* password = "your_wifi_password_here"; // WiFi password
 
-// Replace the next variables with your SSID/Password combination
-const char* ssid = "your_wlan_name_goes_here";
-const char* password = "wlan_password_goes_here";
-const char* mqttServer = "mqtt_server_ip_goes_here";
-const int mqttPort = 1883;
-const char* mqttUser = "homeassistants_mqtt_username_goes_here";
-const char* mqttPassword = "homeassistans_mqtt_password_goes_here";
-int var;
-WiFiClient espClient;
-PubSubClient client(espClient);
+// Using a static IP address to avoid using DHCP will save battery
+const bool useDHCP = false; // use DHCP (true/false)
+IPAddress ip(192, 168, 0, 100); // WiFi Client IP when useDHCP == false
+IPAddress gateway(192, 168, 0, 1); // Statis client gateway when useDHCP == false
+IPAddress subnet(255, 255, 255, 0); // Static client subnet when useDHCP == false
 
-// use static ip to avoid DHCP wait time
-IPAddress ip(192, 168, 254, 1);
-IPAddress gateway(192, 168, 0, 1);
-IPAddress subnet (255, 255, 255, 0);
+// MQTT configuration
+const char* mqttServer = "192.168.0.50"; // MQTT broker IP
+const char* mqttUser = "your_mqtt_username"; // MQTT username
+const char* mqttPassword = "your_mqtt_password"; // MQTT password
+const int mqttPort = 1883; // MQTT port (default: 1883)
 
-void setup(){
-  Serial.begin(115200);
-  delay(100); //Take some time to open up the Serial Monitor
+// Retry configuration
+const int retryWaitTime = 30; // Retry wait time in minutes
+const int retryMaxTimes = 5; // Maximum retry times
 
-  //get wakeup bit
-  uint64_t wakeupBit = esp_sleep_get_ext1_wakeup_status();
-  //if it didnt woke because of flap or door, we dont need to do anything.
-  if(esp_sleep_get_wakeup_cause() == 2){// 2 is RTC_CTRL - the IOs controlled by rtc
-  				//Setup WiFi
-  				Serial.print("Connecting to ");
-  				Serial.print(ssid);
+char* state;
+RTC_DATA_ATTR int retryCount;
+RTC_DATA_ATTR char* retryState;
 
-          WiFi.config(ip, gateway, subnet);
-					WiFi.begin(ssid, password);
-        
-          var = 0;
-					while (WiFi.status() != WL_CONNECTED && var <= 25) {
-              delay(1000);
-              Serial.print(".");
-						  var++;
-          }
-          Serial.println();
+void setup()
+{
+    Serial.begin(115200);
+    delay(100); // Take some time to open up the Serial Monitor
+    Serial.println("Starting up...");
 
-					if (WiFi.status() != WL_CONNECTED) {
-    		  		Serial.println("Unable to connect to WiFi, going back to sleep");
-      				esp_deep_sleep_start();
-    			}
-		
-					Serial.println("WiFi connected");
-          Serial.println("IP address: ");
-          Serial.println(WiFi.localIP());
-        
-          Serial.println("Connecting to MQTT...");
-					client.setServer(mqttServer, mqttPort);
-         
-		 			var = 0;
-          while (!client.connected() && var < 3) {
-						if (client.connect("paesslersMailbox", mqttUser, mqttPassword )) {  
-							Serial.println("MQTT connected");
-         		} else {
-         			Serial.print("Failed with state ");
-              Serial.println(client.state());
-              delay(2000);
+    // get wakeup bit
+    uint64_t wakeupBit = esp_sleep_get_ext1_wakeup_status();
+
+    // if it didnt woke because of flap or door or retry timer, we only need to configure internal pullups/downs.
+    if (esp_sleep_get_wakeup_cause() == 2 || esp_sleep_get_wakeup_cause() == 3) { // 2 is GPIO, 3 is retry timer
+        if (esp_sleep_get_wakeup_cause() == 3) { // retry timer
+            Serial.print("Retry processing previous state: ");
+            Serial.println(retryState);
+            Serial.print("Retry count: ");
+            Serial.println(retryCount);
+            state = retryState;
+        }
+        else { // mail arrived or emptied
+            if (wakeupBit & GPIO_SEL_25) {
+                state = "arrived";
             }
-						var++;
-					}
-        
-          if (wakeupBit & GPIO_SEL_25) {
-            // GPIO 25 woke up
-            Serial.println("a letter arrived");
-            client.publish("mailbox/action", "arrived");
-          } 
-          else{
-            // must be GPIO 26 - we can't as explicitly because with unarmed flap this doesnt work.
-            Serial.println("emptied mailbox");
-            client.publish("mailbox/action", "emptied");
-          }
-					// disconnect WiFi
-					WiFi.disconnect();
-  }
+            else {
+                state = "emptied";
+            }
+        }
 
-  //we need the internal pullups/downs to work so wee need an option to keep the power for them on during sleep.
-  //note: when you use external pulldowns (10K) instead of the internal ones you can save around 10µA in deepsleep  (then comment out the next 5 lines)
-  //note2: don't use gpio34-39 when using internal pullup/downs - they don't have them.
-  esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
-  gpio_pullup_dis(GPIO_NUM_25);
-  gpio_pulldown_en(GPIO_NUM_25);
-  gpio_pullup_dis(GPIO_NUM_26);
-  gpio_pulldown_en(GPIO_NUM_26);
+        Serial.print("Connecting to ");
+        Serial.print(ssid);
 
-  /*
-   * Important: Assume someone threw a magazine into our Mailbox, blocking the flap. This would cause it to
-   * permanently wake up and drain our battery. So we'll only arm the mailbox door switch after a letter
-   * arrived.
-   */
-  
-  if(wakeupBit & GPIO_SEL_25){
-  //enable gpio 25 and 26 for deep sleep (using bit or) - wakeup if any of those go high.
-    Serial.println("only arming door");
-    esp_sleep_enable_ext1_wakeup(GPIO_SEL_26,ESP_EXT1_WAKEUP_ANY_HIGH);
-  }
-  else{
-    //arm both flap and door.
-    Serial.println("arming flap");
-    esp_sleep_enable_ext1_wakeup(GPIO_SEL_25,ESP_EXT1_WAKEUP_ANY_HIGH);
-  }
-  //Go to sleep now
-  Serial.println("Going to sleep now");
-  esp_deep_sleep_start();
-  Serial.println("This will never be printed");
+        // Setup WiFi
+        WiFiClient espClient;
+        if (!useDHCP)
+            WiFi.config(ip, gateway, subnet);
+        WiFi.begin(ssid, password);
+
+        int trycount = 0;
+        // try to connect to WiFi for another 10 seconds
+        while (WiFi.status() != WL_CONNECTED && trycount <= 10) {
+            delay(1000);
+            Serial.print(".");
+            trycount++;
+        }
+        Serial.println();
+
+        if (WiFi.status() == WL_CONNECTED) {
+            Serial.println("WiFi connected");
+            Serial.print("IP address: ");
+            Serial.println(WiFi.localIP());
+
+            Serial.println("Connecting to MQTT...");
+            PubSubClient client(espClient);
+            client.setServer(mqttServer, mqttPort);
+
+            trycount = 0; // reset trycount
+            // try to connect to MQTT server, retry two times if connection fails
+            while (!client.connected() && trycount <= 2) {
+                if (client.connect("Mailbox", mqttUser, mqttPassword)) {
+                    Serial.println("MQTT connected");
+                }
+                else {
+                    Serial.print("Failed with state ");
+                    Serial.println(client.state());
+                    delay(1000);
+                }
+                trycount++;
+            }
+
+            if (client.connected()) {
+                resetRetry();
+                if (state == "arrived") {
+                    client.publish("mailbox/action", "arrived");
+                    Serial.println("A letter arrived, arming door");
+                    esp_sleep_enable_ext1_wakeup(GPIO_SEL_26, ESP_EXT1_WAKEUP_ANY_HIGH);
+                }
+                else if (state == "emptied") {
+                    client.publish("mailbox/action", "emptied");
+                    Serial.println("Mailbox emptied, arming flap");
+                    esp_sleep_enable_ext1_wakeup(GPIO_SEL_25, ESP_EXT1_WAKEUP_ANY_HIGH);
+                }
+            }
+            else {
+                Serial.println("Unable to connect to MQTT server");
+                retry();
+            }
+        }
+        else {
+            Serial.println("Unable to connect to WiFi network");
+            retry();
+        }
+
+        // disconnect WiFi
+        WiFi.disconnect();
+    }
+    else {
+        Serial.println("Arming flap and door");
+        esp_sleep_enable_ext1_wakeup(GPIO_SEL_25 | GPIO_SEL_26, ESP_EXT1_WAKEUP_ANY_HIGH);
+    }
+
+    /*
+    we need the internal pullups/downs to work so we need an option to keep the power for them on during sleep.
+    note: when you use external pulldowns (10K) instead of the internal ones you can save around 10µA in deepsleep  (then comment out the next 5 lines)
+    note2: don't use gpio34-39 when using internal pullup/downs - they don't have them.
+    */
+
+    esp_sleep_pd_config(ESP_PD_DOMAIN_RTC_PERIPH, ESP_PD_OPTION_ON);
+    gpio_pullup_dis(GPIO_NUM_25);
+    gpio_pulldown_en(GPIO_NUM_25);
+    gpio_pullup_dis(GPIO_NUM_26);
+    gpio_pulldown_en(GPIO_NUM_26);
+
+    // Go to deep sleep
+    Serial.println("Going to sleep now...");
+    esp_deep_sleep_start();
 }
 
+void retry()
+{
+    // with or without retry mode enabled, listen to GPIO ports
+    esp_sleep_enable_ext1_wakeup(GPIO_SEL_25 | GPIO_SEL_26, ESP_EXT1_WAKEUP_ANY_HIGH);
+    if (retryCount < retryMaxTimes) {
+        Serial.println("An error has occurred, let's try again later");
+        ++retryCount;
+        retryState = state;
+        esp_sleep_enable_timer_wakeup(retryWaitTime * 60000000);
+    }
+    else {
+        Serial.println("Retry failed again. I give up, sorry.");
+        resetRetry();
+    }
+}
 
-void loop(){
-  //This is not going to be called
+void resetRetry()
+{
+    // reset any retry counts and states
+    retryCount = 0;
+    retryState = "cleared";
+}
+
+void loop()
+{
+    // This is not going to be called
 }


### PR DESCRIPTION
After some tedious debugging I've discovered that the detection of the wake-up port is unreliable. When this happens (wakeupStatus == 0) the script checks if either of the ports is (still) HIGH.

I've also added retry functions that are useful when WiFi or MQTT broker are unreliable or temporarily down. The script saves the state, sets a (configurable) time-based deep-sleep and tries to send the message again.

DHCP can now be configured (true/false) for people that do not want to reserve a static IP address.

I've been using this code for a few months now and have not had any issues since.